### PR TITLE
don't install orion in validators

### DIFF
--- a/roles/lacchain-validator-node/tasks/install.yaml
+++ b/roles/lacchain-validator-node/tasks/install.yaml
@@ -29,12 +29,6 @@
 - name: init pantheon
   import_tasks: "init-pantheon.yaml"
 
-- name: install orion
-  import_tasks: "install-orion.yaml"
-
-- name: init orion
-  import_tasks: "init-orion.yaml"
-
 - name: start node
   import_tasks: "start-node.yaml"
   when: first_node
@@ -44,4 +38,3 @@
 
 - name: clean files
   import_tasks: "clean-files.yaml"
-

--- a/roles/lacchain-validator-node/templates/pantheon-config.j2
+++ b/roles/lacchain-validator-node/templates/pantheon-config.j2
@@ -13,9 +13,9 @@ rpc-http-api=["ETH","NET","IBFT","EEA","PRIV"]
 
 
 # Orion
-privacy-enabled=true
-privacy-url="http://127.0.0.1:4444"
-privacy-public-key-file="/root/lacchain/orion/keystore/nodeKey.pub"
+#privacy-enabled=true
+#privacy-url="http://127.0.0.1:4444"
+#privacy-public-key-file="/root/lacchain/orion/keystore/nodeKey.pub"
 
 # Networking
 p2p-host="{{node_ip.stdout}}"


### PR DESCRIPTION
Orion node has been removed from the Ansible installation in Validator nodes.