### PR TITLE
modified Log4j to automatically get rid of old logs

### DIFF
--- a/roles/lacchain-bootnode/files/log.xml
+++ b/roles/lacchain-bootnode/files/log.xml
@@ -13,7 +13,7 @@
         <Policies>
             <TimeBasedTriggeringPolicy />
             <SizeBasedTriggeringPolicy size="10 MB"/>
-        </Policies>
+    	</Policies>
     </RollingFile>
 
     <RollingFile name="debugLog" fileName="/root/lacchain/logs/pantheon_debug.log"
@@ -23,7 +23,13 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_debug/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        
       </RollingFile>
          
         <RollingFile name="infoLog" fileName="/root/lacchain/logs/pantheon_info.log"
@@ -33,7 +39,13 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_info/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+ 
         </RollingFile>
          
         <RollingFile name="errorLog" fileName="/root/lacchain/logs/pantheon_error.log"
@@ -43,7 +55,12 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+ 	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_error/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
 
   </Appenders>

--- a/roles/lacchain-validator-node/files/log.xml
+++ b/roles/lacchain-validator-node/files/log.xml
@@ -13,7 +13,7 @@
         <Policies>
             <TimeBasedTriggeringPolicy />
             <SizeBasedTriggeringPolicy size="10 MB"/>
-        </Policies>
+    	</Policies>
     </RollingFile>
 
     <RollingFile name="debugLog" fileName="/root/lacchain/logs/pantheon_debug.log"
@@ -23,7 +23,13 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_debug/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        
       </RollingFile>
          
         <RollingFile name="infoLog" fileName="/root/lacchain/logs/pantheon_info.log"
@@ -33,7 +39,13 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_info/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+ 
         </RollingFile>
          
         <RollingFile name="errorLog" fileName="/root/lacchain/logs/pantheon_error.log"
@@ -43,7 +55,12 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+ 	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_error/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
 
   </Appenders>

--- a/roles/lacchain-writer-node/files/log.xml
+++ b/roles/lacchain-writer-node/files/log.xml
@@ -13,7 +13,7 @@
         <Policies>
             <TimeBasedTriggeringPolicy />
             <SizeBasedTriggeringPolicy size="10 MB"/>
-        </Policies>
+    	</Policies>
     </RollingFile>
 
     <RollingFile name="debugLog" fileName="/root/lacchain/logs/pantheon_debug.log"
@@ -23,7 +23,13 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_debug/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        
       </RollingFile>
          
         <RollingFile name="infoLog" fileName="/root/lacchain/logs/pantheon_info.log"
@@ -33,7 +39,13 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_info/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+ 
         </RollingFile>
          
         <RollingFile name="errorLog" fileName="/root/lacchain/logs/pantheon_error.log"
@@ -43,7 +55,12 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="10 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="10"/>
+ 	    <DefaultRolloverStrategy>
+                <Delete basePath="/root/lacchain/logs" maxDepth="2">
+                  <IfFileName glob="*_error/app-*.log" />
+                  <IfLastModified age="30d" />
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
 
   </Appenders>


### PR DESCRIPTION
This pull addresses issue #75 ,  now old rotated logs are deleted automatically after 30 days.